### PR TITLE
Remove tar artifacts from the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM gliderlabs/alpine:latest
 RUN apk-install ca-certificates openssl
-ADD https://github.com/coreos/etcd/releases/download/v2.0.10/etcd-v2.0.10-linux-amd64.tar.gz etcd-v2.0.10-linux-amd64.tar.gz
-RUN tar xzvf etcd-v2.0.10-linux-amd64.tar.gz
-RUN mv etcd-v2.0.10-linux-amd64/etcd /bin && mv etcd-v2.0.10-linux-amd64/etcdctl /bin && rm -Rf etcd-v2.0.10-linux-amd64*
+RUN wget https://github.com/coreos/etcd/releases/download/v2.0.10/etcd-v2.0.10-linux-amd64.tar.gz && \
+    tar xzvf etcd-v2.0.10-linux-amd64.tar.gz && \
+    mv etcd-v2.0.10-linux-amd64/etcd etcd-v2.0.10-linux-amd64/etcdctl /bin && \
+    rm -rf etcd-v2.0.10-linux-amd64*
 VOLUME /data
 EXPOSE 2379 2380 4001 7001
 ADD run.sh /bin/run.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ***NOTE: The tags have recently been updated!  Use elcolio/etcd:2.0.X for a specific version.  The current latest is 2.0.10***
 
-This image weighs in at 46.17 MB due to the inclusion of TLS support and etcdctl.  The `-data-dir` is a volume mounted to `/data`, and the default ports are bound to Etcd and exposed.
+This image weighs in at 20.17 MB due to the inclusion of TLS support and etcdctl.  The `-data-dir` is a volume mounted to `/data`, and the default ports are bound to Etcd and exposed.
 
 Recently added a run script so that http is not hard-coded into the Dockerfile (for running over SSL).  Just overwrite `$CLIENT_URLS` and `$PEER_URLS` at runtime (these are the **listening** URLs).  You'll still need to set the `-advertise-client-urls` and `-initial-advertise-peer-urls` flags if the container will be part of a cluster.
 


### PR DESCRIPTION
Using `ADD` and `RUN` to download and untar files leaves those files in the image layers, even if removed later, so [wget/curl is preferred](http://docs.docker.com/engine/articles/dockerfile_best-practices/#add-or-copy). This trims the image down to 20.17 MB (from 36.92)!
