### PR TITLE
Exec etcd in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -18,6 +18,4 @@ fi
 ETCD_CMD="/bin/etcd -data-dir=/data -listen-peer-urls=${PEER_URLS} -listen-client-urls=${CLIENT_URLS} $*"
 echo -e "Running '$ETCD_CMD'\nBEGIN ETCD OUTPUT\n"
 
-$ETCD_CMD
-
-echo -e "\nETCD HAS DIED\n"
+exec $ETCD_CMD


### PR DESCRIPTION
`exec`ing etcd allows it to receive signals, such as when stopping the container (which were instead caught by sh). This fixes stopping the container timing out and just being killed, and allows etcd to exit quickly and gracefully.
